### PR TITLE
Remove MySQL related packages

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,8 +20,6 @@ case node[:platform]
     
     when "amazon"
     # node.set['php']['packages'] = ['php55w', 'php55w-devel', 'php55w-cli', 'php55w-snmp', 'php55w-soap', 'php55w-xml', 'php55w-xmlrpc', 'php55w-process', 'php55w-mysqlnd', 'php55w-pecl-memcache', 'php55w-opcache', 'php55w-pdo', 'php55w-imap', 'php55w-mbstring']
-    node.set['mysql']['server']['packages'] = %w{mysql55-server}
-    node.set['mysql']['client']['packages'] = %w{mysql55}
     
     # add the webtatic repository
     yum_repository "webtatic" do
@@ -63,8 +61,6 @@ case node[:platform]
   end
   
   node.set['php']['packages'] = ['php55w', 'php55w-devel', 'php55w-cli', 'php55w-snmp', 'php55w-soap', 'php55w-xml', 'php55w-xmlrpc', 'php55w-process', 'php55w-mysqlnd', 'php55w-pecl-memcache', 'php55w-opcache', 'php55w-pdo', 'php55w-imap', 'php55w-mbstring']
-  node.set['mysql']['server']['packages'] = %w{mysql55-server}
-  node.set['mysql']['client']['packages'] = %w{mysql55}
   
   include_recipe "php"
 


### PR DESCRIPTION
The packages aren't directly related to PHP, so they should be handled in another cookbook for setting them up. The PHP cookbook could then depend on the mysql cookbook (similar to how the php cookbook depends on mysql cookbook).